### PR TITLE
Add redirect links

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -11,6 +11,11 @@
       "source": "/mastodon",
       "destination": "https://mas.to/@atila",
       "permanent": true
+    },
+    {
+      "source": "/twitter",
+      "destination": "https://twitter.com/AtilaFassina",
+      "permanent": true
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "astro",
+  "redirects": [
+    {
+      "source": "/youtube",
+      "destination": "https://youtube.com/@AtilaIO",
+      "permanent": true
+    },
+    {
+      "source": "/mastodon",
+      "destination": "https://mas.to/@atila",
+      "permanent": true
+    }
+  ]
+}


### PR DESCRIPTION
The redirect links don't work for some reason. Like /youtube, /linkedin, /mastodon etc.
While using Astro, defining those in `vercel.json` makes it work.

I added YouTube and Mastodon links but couldn't find other profiles. Let me know where they are and I'll add the other links